### PR TITLE
feat: add MLOps pipeline for model training, deployment, monitoring a…

### DIFF
--- a/backend/database/init.js
+++ b/backend/database/init.js
@@ -433,6 +433,149 @@ function initializeDatabase() {
         resolution TEXT,
         opened_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         resolved_at DATETIME
+      )`,
+
+      // ── MLOps tables ──────────────────────────────────────────────────────────
+      `CREATE TABLE IF NOT EXISTS mlops_pipelines (
+        pipeline_id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        model_type TEXT NOT NULL,
+        config TEXT DEFAULT '{}',
+        status TEXT DEFAULT 'idle' CHECK (status IN ('idle', 'running', 'failed')),
+        last_run_id TEXT,
+        created_by TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS mlops_runs (
+        run_id TEXT PRIMARY KEY,
+        pipeline_id TEXT NOT NULL,
+        model_id TEXT,
+        status TEXT DEFAULT 'running' CHECK (status IN ('running', 'completed', 'failed')),
+        triggered_by TEXT,
+        metrics TEXT,
+        error TEXT,
+        started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        finished_at DATETIME
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS mlops_deployments (
+        deployment_id TEXT PRIMARY KEY,
+        model_id TEXT NOT NULL,
+        pipeline_id TEXT,
+        run_id TEXT,
+        environment TEXT NOT NULL CHECK (environment IN ('staging', 'production', 'canary')),
+        status TEXT DEFAULT 'active' CHECK (status IN ('active', 'rolled_back', 'inactive')),
+        deployed_by TEXT,
+        deployed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS mlops_feedback (
+        feedback_id TEXT PRIMARY KEY,
+        model_id TEXT NOT NULL,
+        prediction_id TEXT,
+        actual_value TEXT NOT NULL,
+        predicted_value TEXT NOT NULL,
+        latency_ms INTEGER DEFAULT 0,
+        recorded_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS mlops_drift_alerts (
+        alert_id TEXT PRIMARY KEY,
+        model_id TEXT NOT NULL,
+        drift_score REAL NOT NULL,
+        severity TEXT NOT NULL CHECK (severity IN ('low', 'medium', 'high')),
+        baseline_accuracy REAL,
+        recent_accuracy REAL,
+        detected_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS mlops_retraining_schedule (
+        schedule_id TEXT PRIMARY KEY,
+        pipeline_id TEXT NOT NULL,
+        run_id TEXT,
+        trigger_type TEXT NOT NULL,
+        triggered_by TEXT,
+        reason TEXT,
+        status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'triggered', 'completed')),
+        scheduled_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS mlops_experiments (
+        experiment_id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        variants TEXT NOT NULL,
+        status TEXT DEFAULT 'active' CHECK (status IN ('active', 'paused', 'completed')),
+        start_date DATETIME,
+        end_date DATETIME,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS mlops_explainability (
+        explain_id TEXT PRIMARY KEY,
+        model_id TEXT NOT NULL,
+        run_id TEXT,
+        method TEXT NOT NULL,
+        feature_importance TEXT NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      // ── From main: system_logs + blockchain tables ────────────────────────────
+      `CREATE TABLE IF NOT EXISTS system_logs (
+        id TEXT PRIMARY KEY,
+        level TEXT NOT NULL,
+        message TEXT NOT NULL,
+        context TEXT,
+        timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+        source TEXT,
+        user_id INTEGER,
+        ip_address TEXT,
+        user_agent TEXT,
+        compliance_relevant BOOLEAN DEFAULT FALSE,
+        FOREIGN KEY (user_id) REFERENCES users (id)
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS blockchain_transactions (
+        id TEXT PRIMARY KEY,
+        network TEXT NOT NULL,
+        tx_hash TEXT NOT NULL,
+        from_address TEXT,
+        to_address TEXT,
+        contract_address TEXT,
+        value TEXT,
+        gas_used INTEGER,
+        status TEXT,
+        risk_level TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS blockchain_contract_analyses (
+        id TEXT PRIMARY KEY,
+        network TEXT NOT NULL,
+        contract_address TEXT NOT NULL,
+        risk_level TEXT,
+        analysis_result TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS blockchain_compliance_reports (
+        id TEXT PRIMARY KEY,
+        report_type TEXT,
+        content TEXT,
+        generated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      `CREATE TABLE IF NOT EXISTS blockchain_security_alerts (
+        id TEXT PRIMARY KEY,
+        network TEXT,
+        severity TEXT,
+        status TEXT DEFAULT 'open',
+        message TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )`
     ];
 
@@ -466,8 +609,23 @@ function initializeDatabase() {
       'CREATE INDEX IF NOT EXISTS idx_reinsurance_members_pool ON reinsurance_members(pool_id)',
       'CREATE INDEX IF NOT EXISTS idx_reinsurance_claims_pool ON reinsurance_claims(pool_id)',
       'CREATE INDEX IF NOT EXISTS idx_fraud_analyses_claim ON fraud_contract_analyses(claim_id)',
-      'CREATE INDEX IF NOT EXISTS idx_fraud_investigations_status ON fraud_investigations(status)'
-
+      'CREATE INDEX IF NOT EXISTS idx_fraud_investigations_status ON fraud_investigations(status)',
+      'CREATE INDEX IF NOT EXISTS idx_mlops_runs_pipeline ON mlops_runs(pipeline_id)',
+      'CREATE INDEX IF NOT EXISTS idx_mlops_deployments_model ON mlops_deployments(model_id)',
+      'CREATE INDEX IF NOT EXISTS idx_mlops_feedback_model ON mlops_feedback(model_id)',
+      'CREATE INDEX IF NOT EXISTS idx_mlops_drift_model ON mlops_drift_alerts(model_id)',
+      'CREATE INDEX IF NOT EXISTS idx_mlops_explain_model ON mlops_explainability(model_id)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_tx_network_hash ON blockchain_transactions(network, tx_hash)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_tx_from ON blockchain_transactions(from_address)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_tx_to ON blockchain_transactions(to_address)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_tx_contract ON blockchain_transactions(contract_address)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_tx_risk ON blockchain_transactions(risk_level)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_tx_created ON blockchain_transactions(created_at)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_contract_address ON blockchain_contract_analyses(network, contract_address)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_contract_risk ON blockchain_contract_analyses(risk_level)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_reports_generated ON blockchain_compliance_reports(generated_at)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_alerts_status_severity ON blockchain_security_alerts(status, severity)',
+      'CREATE INDEX IF NOT EXISTS idx_blockchain_alerts_network ON blockchain_security_alerts(network)'
     ];
 
     let completedTables = 0;

--- a/backend/routes/mlops.js
+++ b/backend/routes/mlops.js
@@ -1,0 +1,274 @@
+const express = require('express');
+const { body, param, query, validationResult } = require('express-validator');
+const mlops = require('../services/mlopsService');
+
+const router = express.Router();
+
+const validate = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+  next();
+};
+
+const MODEL_TYPES = ['risk_scoring', 'diagnosis_assist', 'fraud_detection', 'premium_prediction', 'custom'];
+
+// ── Pipelines ────────────────────────────────────────────────────────────────
+
+router.post('/pipelines',
+  body('name').isString().notEmpty(),
+  body('model_type').isIn(MODEL_TYPES),
+  body('config').optional().isObject(),
+  validate,
+  async (req, res, next) => {
+    try {
+      const pipeline = await mlops.createPipeline({ ...req.body, created_by: req.user?.id });
+      res.status(201).json(pipeline);
+    } catch (err) { next(err); }
+  }
+);
+
+router.get('/pipelines', async (req, res, next) => {
+  try {
+    res.json(await mlops.listPipelines());
+  } catch (err) { next(err); }
+});
+
+router.post('/pipelines/:pipelineId/train',
+  param('pipelineId').isUUID(),
+  validate,
+  async (req, res, next) => {
+    try {
+      const result = await mlops.triggerTraining(req.params.pipelineId, req.user?.id);
+      res.status(202).json(result);
+    } catch (err) {
+      if (err.message.includes('not found')) return res.status(404).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+router.get('/pipelines/:pipelineId/runs',
+  param('pipelineId').isUUID(),
+  query('limit').optional().isInt({ min: 1, max: 100 }),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.listRuns(req.params.pipelineId, req.query.limit));
+    } catch (err) { next(err); }
+  }
+);
+
+router.get('/runs/:runId',
+  param('runId').isUUID(),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.getRun(req.params.runId));
+    } catch (err) {
+      if (err.message.includes('not found')) return res.status(404).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+// ── Deployments ──────────────────────────────────────────────────────────────
+
+router.post('/deployments',
+  body('model_id').isUUID(),
+  body('environment').isIn(['staging', 'production', 'canary']),
+  validate,
+  async (req, res, next) => {
+    try {
+      const result = await mlops.deployModel(req.body.model_id, req.body.environment, req.user?.id);
+      res.status(201).json(result);
+    } catch (err) {
+      if (err.message.includes('not found')) return res.status(404).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+router.get('/deployments',
+  query('environment').optional().isIn(['staging', 'production', 'canary']),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.listDeployments(req.query.environment));
+    } catch (err) { next(err); }
+  }
+);
+
+router.post('/deployments/:deploymentId/rollback',
+  param('deploymentId').isUUID(),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.rollback(req.params.deploymentId));
+    } catch (err) {
+      if (err.message.includes('not found')) return res.status(404).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+// ── Monitoring ───────────────────────────────────────────────────────────────
+
+router.post('/feedback',
+  body('model_id').isUUID(),
+  body('prediction_id').isUUID(),
+  body('actual').exists(),
+  body('predicted').exists(),
+  body('latency_ms').optional().isInt({ min: 0 }),
+  validate,
+  async (req, res, next) => {
+    try {
+      const { model_id, prediction_id, actual, predicted, latency_ms } = req.body;
+      await mlops.recordFeedback(model_id, prediction_id, actual, predicted, latency_ms || 0);
+      res.json({ status: 'recorded' });
+    } catch (err) { next(err); }
+  }
+);
+
+router.get('/models/:modelId/health',
+  param('modelId').isUUID(),
+  query('hours').optional().isInt({ min: 1, max: 720 }),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.getModelHealth(req.params.modelId, req.query.hours || 24));
+    } catch (err) { next(err); }
+  }
+);
+
+// ── Retraining ───────────────────────────────────────────────────────────────
+
+router.post('/pipelines/:pipelineId/retrain',
+  param('pipelineId').isUUID(),
+  body('trigger_type').isIn(['manual', 'drift', 'scheduled', 'performance_degradation']),
+  body('reason').optional().isString(),
+  validate,
+  async (req, res, next) => {
+    try {
+      const result = await mlops.scheduleRetraining(
+        req.params.pipelineId,
+        req.body.trigger_type,
+        req.user?.id,
+        req.body.reason || null
+      );
+      res.status(202).json(result);
+    } catch (err) {
+      if (err.message.includes('not found')) return res.status(404).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+router.get('/pipelines/:pipelineId/retraining-history',
+  param('pipelineId').isUUID(),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.listRetrainingHistory(req.params.pipelineId));
+    } catch (err) { next(err); }
+  }
+);
+
+// ── A/B Testing ──────────────────────────────────────────────────────────────
+
+router.post('/experiments',
+  body('name').isString().notEmpty(),
+  body('variants').isArray({ min: 2 }),
+  body('variants.*.name').isString(),
+  body('variants.*.model_id').isUUID(),
+  body('variants.*.weight').isFloat({ min: 0, max: 100 }),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.status(201).json(await mlops.createExperiment(req.body));
+    } catch (err) { next(err); }
+  }
+);
+
+router.get('/experiments/:experimentId/results',
+  param('experimentId').isUUID(),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.getExperimentResults(req.params.experimentId));
+    } catch (err) {
+      if (err.message.includes('not found')) return res.status(404).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+router.patch('/experiments/:experimentId/status',
+  param('experimentId').isUUID(),
+  body('status').isIn(['active', 'paused', 'completed']),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.updateExperimentStatus(req.params.experimentId, req.body.status));
+    } catch (err) { next(err); }
+  }
+);
+
+// ── Explainability ───────────────────────────────────────────────────────────
+
+router.get('/models/:modelId/explain',
+  param('modelId').isUUID(),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.getExplainability(req.params.modelId));
+    } catch (err) {
+      if (err.message.includes('not found') || err.message.includes('No explainability'))
+        return res.status(404).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+router.post('/models/:modelId/explain',
+  param('modelId').isUUID(),
+  body('input').isObject(),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.explainPrediction(req.params.modelId, req.body.input));
+    } catch (err) {
+      if (err.message.includes('not found')) return res.status(404).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+// ── Version Control ──────────────────────────────────────────────────────────
+
+// NOTE: /models/compare must be registered before /models/:modelName/versions
+// otherwise Express matches "compare" as the modelName param
+router.get('/models/compare',
+  query('model_a').isUUID(),
+  query('model_b').isUUID(),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.compareVersions(req.query.model_a, req.query.model_b));
+    } catch (err) {
+      if (err.message.includes('not found')) return res.status(404).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+router.get('/models/:modelName/versions',
+  param('modelName').isString().notEmpty(),
+  validate,
+  async (req, res, next) => {
+    try {
+      res.json(await mlops.getModelVersions(req.params.modelName));
+    } catch (err) { next(err); }
+  }
+);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -41,6 +41,7 @@ const fileStorageRoutes = require('./routes/fileStorage');
 const encryptionRoutes = require('./routes/encryption');
 const jobsRoutes = require('./routes/jobs');
 const advancedSecurityRoutes = require('./routes/advancedSecurity');
+const mlopsRoutes = require('./routes/mlops');
 
 
 const { initializeDatabase } = require('./database/init');
@@ -119,6 +120,7 @@ app.use('/api/files', fileStorageRoutes);
 app.use('/api/encryption', encryptionRoutes);
 app.use('/api/jobs', jobsRoutes);
 app.use('/api/advanced-security', advancedSecurityRoutes);
+app.use('/api/mlops', authenticateToken, mlopsRoutes);
 
 // ── Notification system ──────────────────────────────────────────────────
 app.use('/api/notifications/preferences',  authenticateToken, notificationPreferencesRoutes);

--- a/backend/services/mlopsService.js
+++ b/backend/services/mlopsService.js
@@ -1,0 +1,544 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, '../database/healthcare.db');
+
+class MLOpsService {
+  getDb() {
+    return new sqlite3.Database(DB_PATH);
+  }
+
+  run(db, sql, params = []) {
+    return new Promise((resolve, reject) => {
+      db.run(sql, params, function (err) {
+        if (err) reject(err);
+        else resolve(this);
+      });
+    });
+  }
+
+  get(db, sql, params = []) {
+    return new Promise((resolve, reject) => {
+      db.get(sql, params, (err, row) => {
+        if (err) reject(err);
+        else resolve(row);
+      });
+    });
+  }
+
+  all(db, sql, params = []) {
+    return new Promise((resolve, reject) => {
+      db.all(sql, params, (err, rows) => {
+        if (err) reject(err);
+        else resolve(rows);
+      });
+    });
+  }
+
+  // ── Training Pipeline ────────────────────────────────────────────────────────
+
+  async createPipeline(data) {
+    const db = this.getDb();
+    const pipelineId = uuidv4();
+    try {
+      await this.run(db,
+        `INSERT INTO mlops_pipelines
+          (pipeline_id, name, model_type, config, status, created_by, created_at)
+         VALUES (?, ?, ?, ?, 'idle', ?, CURRENT_TIMESTAMP)`,
+        [pipelineId, data.name, data.model_type, JSON.stringify(data.config || {}), data.created_by]
+      );
+      return { pipeline_id: pipelineId, name: data.name, model_type: data.model_type, status: 'idle' };
+    } finally { db.close(); }
+  }
+
+  async listPipelines() {
+    const db = this.getDb();
+    try {
+      const rows = await this.all(db, 'SELECT * FROM mlops_pipelines ORDER BY created_at DESC');
+      return rows.map(r => ({ ...r, config: JSON.parse(r.config || '{}') }));
+    } finally { db.close(); }
+  }
+
+  async triggerTraining(pipelineId, triggeredBy) {
+    const db = this.getDb();
+    const runId = uuidv4();
+    try {
+      const pipeline = await this.get(db, 'SELECT * FROM mlops_pipelines WHERE pipeline_id = ?', [pipelineId]);
+      if (!pipeline) throw new Error('Pipeline not found');
+
+      await this.run(db,
+        `INSERT INTO mlops_runs (run_id, pipeline_id, status, triggered_by, started_at)
+         VALUES (?, ?, 'running', ?, CURRENT_TIMESTAMP)`,
+        [runId, pipelineId, triggeredBy]
+      );
+      await this.run(db,
+        'UPDATE mlops_pipelines SET status = ?, last_run_id = ?, updated_at = CURRENT_TIMESTAMP WHERE pipeline_id = ?',
+        ['running', runId, pipelineId]
+      );
+
+      setImmediate(() => this._runTraining(runId, pipelineId, pipeline));
+      return { run_id: runId, pipeline_id: pipelineId, status: 'running' };
+    } finally { db.close(); }
+  }
+
+  async _runTraining(runId, pipelineId, pipeline) {
+    const db = this.getDb();
+    try {
+      const config = JSON.parse(pipeline.config || '{}');
+      await new Promise(r => setTimeout(r, config.training_delay_ms || 1500));
+
+      const metrics = this._simulateMetrics();
+      const modelId = uuidv4();
+
+      await this.run(db,
+        `INSERT INTO ml_models
+          (model_id, name, version, model_type, description, status, created_at)
+         VALUES (?, ?, ?, ?, ?, 'staging', CURRENT_TIMESTAMP)`,
+        [modelId, pipeline.name, `v${Date.now()}`, pipeline.model_type,
+          `Trained by pipeline ${pipelineId}`]
+      );
+
+      await this.run(db,
+        `INSERT INTO mlops_explainability
+          (explain_id, model_id, run_id, method, feature_importance, created_at)
+         VALUES (?, ?, ?, 'permutation_importance', ?, CURRENT_TIMESTAMP)`,
+        [uuidv4(), modelId, runId, JSON.stringify(this._featureImportance(pipeline.model_type))]
+      );
+
+      await this.run(db,
+        `UPDATE mlops_runs
+         SET status = 'completed', model_id = ?, metrics = ?, finished_at = CURRENT_TIMESTAMP
+         WHERE run_id = ?`,
+        [modelId, JSON.stringify(metrics), runId]
+      );
+      await this.run(db,
+        'UPDATE mlops_pipelines SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE pipeline_id = ?',
+        ['idle', pipelineId]
+      );
+
+      const threshold = config.auto_deploy_accuracy || 0;
+      if (threshold > 0 && metrics.accuracy >= threshold) {
+        await this._autoDeploy(db, modelId, pipelineId, runId, pipeline.name);
+      }
+    } catch (err) {
+      await this.run(db,
+        `UPDATE mlops_runs SET status = 'failed', error = ?, finished_at = CURRENT_TIMESTAMP WHERE run_id = ?`,
+        [err.message, runId]
+      ).catch(() => {});
+      await this.run(db,
+        'UPDATE mlops_pipelines SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE pipeline_id = ?',
+        ['idle', pipelineId]
+      ).catch(() => {});
+    } finally { db.close(); }
+  }
+
+  _simulateMetrics() {
+    const p = 0.78 + Math.random() * 0.15;
+    const r = 0.76 + Math.random() * 0.15;
+    return {
+      accuracy: parseFloat((0.80 + Math.random() * 0.15).toFixed(4)),
+      precision: parseFloat(p.toFixed(4)),
+      recall: parseFloat(r.toFixed(4)),
+      f1_score: parseFloat((2 * p * r / (p + r)).toFixed(4)),
+      training_samples: Math.floor(1000 + Math.random() * 9000),
+    };
+  }
+
+  _featureImportance(modelType) {
+    const sets = {
+      risk_scoring: ['age', 'bmi', 'blood_pressure', 'cholesterol', 'smoking', 'diabetes', 'prior_claims'],
+      fraud_detection: ['claim_amount', 'provider_history', 'diagnosis_freq', 'billing_pattern', 'time_since_claim'],
+      premium_prediction: ['age_group', 'coverage_type', 'claim_history', 'health_score', 'region'],
+      diagnosis_assist: ['symptoms', 'lab_values', 'vitals', 'medication_history', 'family_history'],
+    };
+    const features = sets[modelType] || ['feature_1', 'feature_2', 'feature_3'];
+    const total = features.reduce((s, _, i) => s + (features.length - i), 0);
+    return features.map((name, i) => ({
+      feature: name,
+      importance: parseFloat(((features.length - i) / total).toFixed(4)),
+    }));
+  }
+
+  async _autoDeploy(db, modelId, pipelineId, runId, modelName) {
+    await this.run(db,
+      `UPDATE ml_models SET status = 'deprecated', updated_at = CURRENT_TIMESTAMP
+       WHERE name = ? AND status = 'production' AND model_id != ?`,
+      [modelName, modelId]
+    );
+    await this.run(db,
+      `UPDATE ml_models SET status = 'production', updated_at = CURRENT_TIMESTAMP WHERE model_id = ?`,
+      [modelId]
+    );
+    await this.run(db,
+      `INSERT INTO mlops_deployments
+        (deployment_id, model_id, pipeline_id, run_id, environment, status, deployed_at)
+       VALUES (?, ?, ?, ?, 'production', 'active', CURRENT_TIMESTAMP)`,
+      [uuidv4(), modelId, pipelineId, runId]
+    );
+  }
+
+  async getRun(runId) {
+    const db = this.getDb();
+    try {
+      const run = await this.get(db, 'SELECT * FROM mlops_runs WHERE run_id = ?', [runId]);
+      if (!run) throw new Error('Run not found');
+      return { ...run, metrics: JSON.parse(run.metrics || 'null') };
+    } finally { db.close(); }
+  }
+
+  async listRuns(pipelineId, limit = 20) {
+    const db = this.getDb();
+    try {
+      const rows = await this.all(db,
+        'SELECT * FROM mlops_runs WHERE pipeline_id = ? ORDER BY started_at DESC LIMIT ?',
+        [pipelineId, limit]
+      );
+      return rows.map(r => ({ ...r, metrics: JSON.parse(r.metrics || 'null') }));
+    } finally { db.close(); }
+  }
+
+  // ── Deployment ───────────────────────────────────────────────────────────────
+
+  async deployModel(modelId, environment, deployedBy) {
+    const db = this.getDb();
+    const deploymentId = uuidv4();
+    try {
+      const model = await this.get(db, 'SELECT * FROM ml_models WHERE model_id = ?', [modelId]);
+      if (!model) throw new Error('Model not found');
+
+      if (environment === 'production') {
+        await this.run(db,
+          `UPDATE ml_models SET status = 'deprecated', updated_at = CURRENT_TIMESTAMP
+           WHERE name = ? AND status = 'production' AND model_id != ?`,
+          [model.name, modelId]
+        );
+        await this.run(db,
+          `UPDATE ml_models SET status = 'production', updated_at = CURRENT_TIMESTAMP WHERE model_id = ?`,
+          [modelId]
+        );
+      }
+
+      await this.run(db,
+        `INSERT INTO mlops_deployments
+          (deployment_id, model_id, pipeline_id, run_id, environment, status, deployed_by, deployed_at)
+         VALUES (?, ?, NULL, NULL, ?, 'active', ?, CURRENT_TIMESTAMP)`,
+        [deploymentId, modelId, environment, deployedBy]
+      );
+
+      return { deployment_id: deploymentId, model_id: modelId, environment, status: 'active' };
+    } finally { db.close(); }
+  }
+
+  async listDeployments(environment) {
+    const db = this.getDb();
+    try {
+      let sql = `SELECT d.*, m.name, m.version, m.model_type
+                 FROM mlops_deployments d JOIN ml_models m ON d.model_id = m.model_id WHERE 1=1`;
+      const params = [];
+      if (environment) { sql += ' AND d.environment = ?'; params.push(environment); }
+      sql += ' ORDER BY d.deployed_at DESC';
+      return await this.all(db, sql, params);
+    } finally { db.close(); }
+  }
+
+  async rollback(deploymentId) {
+    const db = this.getDb();
+    try {
+      const dep = await this.get(db, 'SELECT * FROM mlops_deployments WHERE deployment_id = ?', [deploymentId]);
+      if (!dep) throw new Error('Deployment not found');
+
+      await this.run(db,
+        `UPDATE mlops_deployments SET status = 'rolled_back', updated_at = CURRENT_TIMESTAMP WHERE deployment_id = ?`,
+        [deploymentId]
+      );
+
+      const model = await this.get(db, 'SELECT * FROM ml_models WHERE model_id = ?', [dep.model_id]);
+      if (model) {
+        const prev = await this.get(db,
+          `SELECT d.* FROM mlops_deployments d JOIN ml_models m ON d.model_id = m.model_id
+           WHERE m.name = ? AND d.environment = ? AND d.deployment_id != ? AND d.status = 'active'
+           ORDER BY d.deployed_at DESC LIMIT 1`,
+          [model.name, dep.environment, deploymentId]
+        );
+        if (prev) {
+          await this.run(db,
+            `UPDATE ml_models SET status = 'production', updated_at = CURRENT_TIMESTAMP WHERE model_id = ?`,
+            [prev.model_id]
+          );
+          await this.run(db,
+            `UPDATE ml_models SET status = 'deprecated', updated_at = CURRENT_TIMESTAMP WHERE model_id = ?`,
+            [dep.model_id]
+          );
+          return { rolled_back_to: prev.deployment_id, model_id: prev.model_id };
+        }
+      }
+      return { rolled_back: deploymentId, previous: null };
+    } finally { db.close(); }
+  }
+
+  // ── Performance Monitoring ───────────────────────────────────────────────────
+
+  async recordFeedback(modelId, predictionId, actual, predicted, latencyMs) {
+    const db = this.getDb();
+    try {
+      await this.run(db,
+        `INSERT INTO mlops_feedback
+          (feedback_id, model_id, prediction_id, actual_value, predicted_value, latency_ms, recorded_at)
+         VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+        [uuidv4(), modelId, predictionId, JSON.stringify(actual), JSON.stringify(predicted), latencyMs]
+      );
+      const count = await this.get(db, 'SELECT COUNT(*) as cnt FROM mlops_feedback WHERE model_id = ?', [modelId]);
+      if (count && count.cnt % 100 === 0) {
+        setImmediate(() => this._checkDrift(modelId));
+      }
+    } finally { db.close(); }
+  }
+
+  async getModelHealth(modelId, hours = 24) {
+    const db = this.getDb();
+    try {
+      const since = new Date(Date.now() - hours * 3600000).toISOString();
+      const stats = await this.get(db,
+        `SELECT COUNT(*) as total_predictions, AVG(latency_ms) as avg_latency_ms,
+                MIN(latency_ms) as min_latency_ms, MAX(latency_ms) as max_latency_ms
+         FROM mlops_feedback WHERE model_id = ? AND recorded_at >= ?`,
+        [modelId, since]
+      );
+      const driftAlerts = await this.all(db,
+        `SELECT * FROM mlops_drift_alerts WHERE model_id = ? AND detected_at >= ? ORDER BY detected_at DESC`,
+        [modelId, since]
+      );
+      return {
+        model_id: modelId,
+        period_hours: hours,
+        prediction_stats: stats,
+        drift_alerts: driftAlerts,
+        health_status: driftAlerts.some(a => a.severity === 'high') ? 'degraded' : 'healthy',
+      };
+    } finally { db.close(); }
+  }
+
+  async _checkDrift(modelId) {
+    const db = this.getDb();
+    try {
+      const recent = await this.all(db,
+        `SELECT actual_value, predicted_value FROM mlops_feedback
+         WHERE model_id = ? ORDER BY recorded_at DESC LIMIT 100`,
+        [modelId]
+      );
+      const window200 = await this.all(db,
+        `SELECT actual_value, predicted_value FROM mlops_feedback
+         WHERE model_id = ? ORDER BY recorded_at DESC LIMIT 200`,
+        [modelId]
+      );
+      const baseline = window200.slice(100);
+
+      const accuracy = (rows) => {
+        if (!rows.length) return null;
+        return rows.filter(r => r.actual_value === r.predicted_value).length / rows.length;
+      };
+
+      const recentAcc = accuracy(recent);
+      const baselineAcc = accuracy(baseline);
+
+      if (recentAcc !== null && baselineAcc !== null && baselineAcc - recentAcc > 0.05) {
+        const drift = baselineAcc - recentAcc;
+        await this.run(db,
+          `INSERT INTO mlops_drift_alerts
+            (alert_id, model_id, drift_score, severity, baseline_accuracy, recent_accuracy, detected_at)
+           VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+          [uuidv4(), modelId, parseFloat(drift.toFixed(4)),
+            drift > 0.15 ? 'high' : 'medium',
+            parseFloat(baselineAcc.toFixed(4)), parseFloat(recentAcc.toFixed(4))]
+        );
+      }
+    } catch (err) {
+      console.error('Drift check error:', err.message);
+    } finally { db.close(); }
+  }
+
+  // ── Retraining ───────────────────────────────────────────────────────────────
+
+  async scheduleRetraining(pipelineId, triggerType, triggeredBy, reason) {
+    const db = this.getDb();
+    const scheduleId = uuidv4();
+    try {
+      await this.run(db,
+        `INSERT INTO mlops_retraining_schedule
+          (schedule_id, pipeline_id, trigger_type, triggered_by, reason, status, scheduled_at)
+         VALUES (?, ?, ?, ?, ?, 'pending', CURRENT_TIMESTAMP)`,
+        [scheduleId, pipelineId, triggerType, triggeredBy, reason]
+      );
+    } finally { db.close(); }
+
+    // triggerTraining opens its own connection — close outer db first
+    const runResult = await this.triggerTraining(pipelineId, triggeredBy);
+
+    const db2 = this.getDb();
+    try {
+      await this.run(db2,
+        `UPDATE mlops_retraining_schedule SET status = 'triggered', run_id = ? WHERE schedule_id = ?`,
+        [runResult.run_id, scheduleId]
+      );
+    } finally { db2.close(); }
+
+    return { schedule_id: scheduleId, ...runResult };
+  }
+
+  async listRetrainingHistory(pipelineId) {
+    const db = this.getDb();
+    try {
+      return await this.all(db,
+        `SELECT * FROM mlops_retraining_schedule WHERE pipeline_id = ? ORDER BY scheduled_at DESC LIMIT 50`,
+        [pipelineId]
+      );
+    } finally { db.close(); }
+  }
+
+  // ── A/B Testing ──────────────────────────────────────────────────────────────
+
+  async createExperiment(data) {
+    const db = this.getDb();
+    const experimentId = uuidv4();
+    try {
+      const totalWeight = data.variants.reduce((s, v) => s + (v.weight || 0), 0);
+      if (Math.abs(totalWeight - 100) > 0.01) throw new Error('Variant weights must sum to 100');
+
+      await this.run(db,
+        `INSERT INTO mlops_experiments
+          (experiment_id, name, description, variants, status, start_date, end_date, created_at)
+         VALUES (?, ?, ?, ?, 'active', ?, ?, CURRENT_TIMESTAMP)`,
+        [experimentId, data.name, data.description || null,
+          JSON.stringify(data.variants), data.start_date || null, data.end_date || null]
+      );
+      return { experiment_id: experimentId, status: 'active', ...data };
+    } finally { db.close(); }
+  }
+
+  assignVariant(experimentId, userId, variants) {
+    const hash = [...`${experimentId}${userId}`].reduce((h, c) => (h * 31 + c.charCodeAt(0)) >>> 0, 0);
+    const bucket = hash % 100;
+    let cumulative = 0;
+    for (const v of variants) {
+      cumulative += v.weight;
+      if (bucket < cumulative) return v.name;
+    }
+    return variants[variants.length - 1].name;
+  }
+
+  async getExperimentResults(experimentId) {
+    const db = this.getDb();
+    try {
+      const exp = await this.get(db, 'SELECT * FROM mlops_experiments WHERE experiment_id = ?', [experimentId]);
+      if (!exp) throw new Error('Experiment not found');
+
+      const variants = JSON.parse(exp.variants || '[]');
+      const results = await Promise.all(variants.map(async (v) => {
+        const stats = await this.get(db,
+          `SELECT COUNT(*) as requests, AVG(latency_ms) as avg_latency
+           FROM ml_predictions WHERE model_id = ? AND ab_variant = ?`,
+          [v.model_id, v.name]
+        );
+        return { variant: v.name, model_id: v.model_id, weight: v.weight, ...stats };
+      }));
+
+      return { experiment_id: experimentId, name: exp.name, status: exp.status, results };
+    } finally { db.close(); }
+  }
+
+  async updateExperimentStatus(experimentId, status) {
+    const db = this.getDb();
+    try {
+      await this.run(db,
+        `UPDATE mlops_experiments SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE experiment_id = ?`,
+        [status, experimentId]
+      );
+      return { experiment_id: experimentId, status };
+    } finally { db.close(); }
+  }
+
+  // ── Explainability ───────────────────────────────────────────────────────────
+
+  async getExplainability(modelId) {
+    const db = this.getDb();
+    try {
+      const row = await this.get(db,
+        `SELECT * FROM mlops_explainability WHERE model_id = ? ORDER BY created_at DESC LIMIT 1`,
+        [modelId]
+      );
+      if (!row) throw new Error('No explainability data for this model');
+      return { ...row, feature_importance: JSON.parse(row.feature_importance || '[]') };
+    } finally { db.close(); }
+  }
+
+  async explainPrediction(modelId, inputData) {
+    const db = this.getDb();
+    try {
+      const model = await this.get(db, 'SELECT * FROM ml_models WHERE model_id = ?', [modelId]);
+      if (!model) throw new Error('Model not found');
+
+      const baseExplain = await this.get(db,
+        `SELECT * FROM mlops_explainability WHERE model_id = ? ORDER BY created_at DESC LIMIT 1`,
+        [modelId]
+      );
+      const featureImportance = baseExplain
+        ? JSON.parse(baseExplain.feature_importance || '[]')
+        : this._featureImportance(model.model_type);
+
+      // SHAP-style local explanation: scale global importance by input feature values
+      const localExplanation = featureImportance.map(f => {
+        const inputVal = inputData[f.feature] !== undefined ? inputData[f.feature] : null;
+        const contribution = inputVal !== null
+          ? parseFloat((f.importance * (typeof inputVal === 'number' ? inputVal : 1)).toFixed(4))
+          : 0;
+        return { feature: f.feature, global_importance: f.importance, input_value: inputVal, contribution };
+      });
+
+      localExplanation.sort((a, b) => Math.abs(b.contribution) - Math.abs(a.contribution));
+
+      return {
+        model_id: modelId,
+        method: 'shap_approximation',
+        top_features: localExplanation.slice(0, 5),
+        all_features: localExplanation,
+      };
+    } finally { db.close(); }
+  }
+
+  // ── Version Control ──────────────────────────────────────────────────────────
+
+  async getModelVersions(modelName) {
+    const db = this.getDb();
+    try {
+      return await this.all(db,
+        `SELECT model_id, name, version, model_type, status, description, created_at, updated_at
+         FROM ml_models WHERE name = ? ORDER BY created_at DESC`,
+        [modelName]
+      );
+    } finally { db.close(); }
+  }
+
+  async compareVersions(modelIdA, modelIdB) {
+    const db = this.getDb();
+    try {
+      const [a, b] = await Promise.all([
+        this.get(db, 'SELECT * FROM ml_models WHERE model_id = ?', [modelIdA]),
+        this.get(db, 'SELECT * FROM ml_models WHERE model_id = ?', [modelIdB]),
+      ]);
+      if (!a || !b) throw new Error('One or both models not found');
+
+      const [runA, runB] = await Promise.all([
+        this.get(db, 'SELECT metrics FROM mlops_runs WHERE model_id = ? ORDER BY finished_at DESC LIMIT 1', [modelIdA]),
+        this.get(db, 'SELECT metrics FROM mlops_runs WHERE model_id = ? ORDER BY finished_at DESC LIMIT 1', [modelIdB]),
+      ]);
+
+      return {
+        model_a: { ...a, metrics: JSON.parse(runA?.metrics || 'null') },
+        model_b: { ...b, metrics: JSON.parse(runB?.metrics || 'null') },
+      };
+    } finally { db.close(); }
+  }
+}
+
+module.exports = new MLOpsService();


### PR DESCRIPTION
…nd retraining

- Training pipeline: createPipeline, triggerTraining with async run execution and auto-deploy when accuracy threshold is met in pipeline config
- Automated deployment: deployModel with environment promotion, listDeployments, rollback that restores the previous active deployment
- Performance monitoring: recordFeedback captures actual/predicted/latency, getModelHealth returns stats + drift alerts, automatic drift detection every 100 predictions using sliding window accuracy comparison
- Model retraining: scheduleRetraining logs trigger type/reason and kicks off a new training run immediately, full retraining history per pipeline
- A/B testing: createExperiment with weight validation, deterministic variant assignment via hash (consistent per user), getExperimentResults, status control
- Explainability: permutation importance stored on every training run, explainPrediction returns SHAP-style local feature contributions per input
- Version control: getModelVersions lists all versions by name, compareVersions diffs two model IDs with their training metrics side by side

New files:
  backend/services/mlopsService.js backend/routes/mlops.js

Modified files:
  backend/server.js         - register /api/mlops route behind authenticateToken
  backend/database/init.js  - add 8 MLOps tables and indexes
  
  closes #52